### PR TITLE
Fix: Correct Timer drift and toast notification delay

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000 // FIX: Changed from 1000000ms (~16 mins) to 5000ms (5s)
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
- Replaced the `setInterval` logic in the Timer component with a more accurate `requestAnimationFrame` and `Date.now()` approach to eliminate timer drift.
- Reduced the toast notification removal delay in the `useToast` hook from ~16 minutes to a more sensible 5 seconds.