### PR TITLE
Refine Genkit integration and Tailwind config

### DIFF
--- a/src/ai/flows/generate-soundscape.ts
+++ b/src/ai/flows/generate-soundscape.ts
@@ -4,11 +4,8 @@
  * @fileOverview Generates a soundscape based on the user's mood description.
  */
 
-// FIX: Import from modernized Genkit packages
-import { defineFlow } from '@genkit-ai/flow';
-import { generate } from '@genkit-ai/ai';
 import { z } from 'zod';
-import { model } from '@/ai/genkit'; // Import the model reference
+import { ai, model } from '@/ai/genkit'; // Import the Genkit instance and model reference
 
 // FIX: Define the available sound assets vocabulary (Crucial for mapping to audio files)
 const AvailableSounds = z.enum([
@@ -45,13 +42,13 @@ const GenerateSoundscapeOutputSchema = z.object({
 export type GenerateSoundscapeOutput = z.infer<typeof GenerateSoundscapeOutputSchema>;
 
 // FIX: Define the flow using the modern approach
-export const generateSoundscapeFlow = defineFlow(
-  {
-    name: 'generateSoundscapeFlow',
-    inputSchema: GenerateSoundscapeInputSchema,
-    outputSchema: GenerateSoundscapeOutputSchema,
-  },
-  async (input) => {
+export const generateSoundscapeFlow = ai.defineFlow(
+  {
+    name: 'generateSoundscapeFlow',
+    inputSchema: GenerateSoundscapeInputSchema,
+    outputSchema: GenerateSoundscapeOutputSchema,
+  },
+  async (input: GenerateSoundscapeInput) => {
     // FIX: Improved prompt engineering for structured, constrained output
     const prompt = `You are an expert sound designer creating focus soundscapes.
 
@@ -70,8 +67,8 @@ export const generateSoundscapeFlow = defineFlow(
     Ensure the output strictly adheres to the required JSON schema.
     `;
 
-    // FIX: Use the 'generate' function
-    const result = await generate({
+    // FIX: Use the 'generate' function from the Genkit instance
+    const { output } = await ai.generate({
       model: model,
       prompt: prompt,
       output: { schema: GenerateSoundscapeOutputSchema },
@@ -80,8 +77,10 @@ export const generateSoundscapeFlow = defineFlow(
       }
     });
 
-    return result.output();
-  }
+    if (!output) throw new Error('Failed to generate soundscape');
+
+    return output;
+  }
 );
 
 // Helper function for server action compatibility

--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,15 +1,11 @@
-// FIX: Modernized Genkit initialization
-import { initializeGenkit } from '@genkit-ai/core';
+// FIX: Modernized Genkit initialization using the primary `genkit` entry point
+import { genkit } from 'genkit';
 import { googleAI, gemini15Flash } from '@genkit-ai/googleai';
 
 // Initialize Genkit configuration
-export const config = initializeGenkit({
-  plugins: [googleAI()],
-  flow: {
-    sincerity: true, // Recommended for production flows
-  },
-  // Enable tracing/metrics only in development
-  enableTracingAndMetrics: process.env.NODE_ENV !== 'production',
+export const ai = genkit({
+  plugins: [googleAI()],
+  // Tracing and metrics can be enabled via environment or plugin configuration
 });
 
 // Export the specific model reference (Gemini 1.5 Flash)

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,17 +1,18 @@
-import type {Config} from 'tailwindcss';
+import type { Config } from 'tailwindcss';
 
 export default {
-  // ... (darkMode, content)
-  theme: {
-    extend: {
-      fontFamily: {
+  darkMode: ['class'],
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
         // FIX: Use the CSS variable defined in layout.tsx
-        body: ['var(--font-inter)', 'sans-serif'],
-        headline: ['var(--font-inter)', 'sans-serif'],
-        code: ['monospace'],
-      },
+        body: ['var(--font-inter)', 'sans-serif'],
+        headline: ['var(--font-inter)', 'sans-serif'],
+        code: ['monospace'],
+      },
       // ... (colors, borderRadius, keyframes, animation remain the same)
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [require('tailwindcss-animate')],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- Use `genkit` for AI initialization and expose Gemini model
- Update flow generation to rely on shared `ai` instance and return structured output
- Define Tailwind `darkMode` and `content` options for proper typing

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689f5d759de0832e9565ac5440a8b5fe